### PR TITLE
ci: Add Ruby 2.7 to test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,14 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        version: ["3.0", "3.1", "3.2", "3.3", "3.4"]
+        version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         exclude:
           - runner: ubuntu-20.04
             version: "3.4"
+          - runner: ubuntu-22.04
+            version: "2.7"
+          - runner: ubuntu-24.04
+            version: "2.7"
           - runner: ubuntu-24.04
             version: "3.0"
           - runner: ubuntu-24.04
@@ -38,10 +42,14 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        version: ["3.0.5", "3.1.3", "3.2.6", "3.3.1", "3.4.1"]
+        version: ["2.7.6", "3.0.5", "3.1.3", "3.2.6", "3.3.1", "3.4.1"]
         exclude:
           - runner: ubuntu-20.04
             version: "3.4.1"
+          - runner: ubuntu-22.04
+            version: "2.7.6"
+          - runner: ubuntu-24.04
+            version: "2.7.6"
           - runner: ubuntu-24.04
             version: "3.0.5"
           - runner: ubuntu-24.04
@@ -63,11 +71,17 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        version: ["3.0", "3.1", "3.2", "3.3", "3.4"]
+        version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         testcase: [with_lockfile]
         exclude:
           - runner: ubuntu-20.04
             version: "3.4"
+            testcase: "with_lockfile"
+          - runner: ubuntu-22.04
+            version: "2.7"
+            testcase: "with_lockfile"
+          - runner: ubuntu-24.04
+            version: "2.7"
             testcase: "with_lockfile"
           - runner: ubuntu-24.04
             version: "3.0"
@@ -94,11 +108,17 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
-        version: ["3.0", "3.1", "3.2", "3.3", "3.4"]
+        version: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
         testcase: [with_lockfile]
         exclude:
           - runner: ubuntu-20.04
             version: "3.4"
+            testcase: "with_lockfile"
+          - runner: ubuntu-22.04
+            version: "2.7"
+            testcase: "with_lockfile"
+          - runner: ubuntu-24.04
+            version: "2.7"
             testcase: "with_lockfile"
           - runner: ubuntu-24.04
             version: "3.0"


### PR DESCRIPTION
We've stated that this workflow supports Ruby 2.7 or later on README.md, but we haven't tested Ruby 2.7 on CI.